### PR TITLE
feat/LA-17-AUTH_Save_ArticleDraft

### DIFF
--- a/computer_alerts-be/src/main/java/com/calerts/computer_alertsbe/articlesubdomain/businesslayer/ArticleService.java
+++ b/computer_alerts-be/src/main/java/com/calerts/computer_alertsbe/articlesubdomain/businesslayer/ArticleService.java
@@ -18,6 +18,7 @@ public interface ArticleService {
     Mono<List<ArticleResponseModel>> searchArticles(String query);
     Mono<ArticleResponseModel> createArticle(Mono<ArticleRequestModel> articleRequestModel);
     Mono<Void> acceptArticle(String articleId);
+    Mono<ArticleResponseModel> createArticleDraft(Mono<ArticleRequestModel> articleRequestModel);
 
 
 

--- a/computer_alerts-be/src/main/java/com/calerts/computer_alertsbe/articlesubdomain/businesslayer/ArticleServiceImpl.java
+++ b/computer_alerts-be/src/main/java/com/calerts/computer_alertsbe/articlesubdomain/businesslayer/ArticleServiceImpl.java
@@ -94,6 +94,22 @@ public class ArticleServiceImpl implements ArticleService {
                 });
     }
 
+    @Override
+    public Mono<ArticleResponseModel> createArticleDraft(Mono<ArticleRequestModel> articleRequestModel) {
+        return articleRequestModel
+                .filter(article -> article.getTitle() != null && !article.getTitle().isEmpty())
+                .switchIfEmpty(Mono.error(new BadRequestException("Article title must not be empty")))
+                .filter(article -> article.getWordCount() != 0 && article.getWordCount() > 112)
+                .switchIfEmpty(Mono.error(new BadRequestException("Article must have a valid word count")))
+                .map(EntityModelUtil::toArticleEntity)
+                .map(article -> {
+                    article.setArticleStatus(ArticleStatus.DRAFT);
+                    article.setRequestCount(0);
+                    return article;
+                })
+                .flatMap(articleRepository::save)
+                .map(EntityModelUtil::toArticleResponseModel);
+    }
 
 
     @Override

--- a/computer_alerts-be/src/main/java/com/calerts/computer_alertsbe/articlesubdomain/presentationlayer/ArticleController.java
+++ b/computer_alerts-be/src/main/java/com/calerts/computer_alertsbe/articlesubdomain/presentationlayer/ArticleController.java
@@ -82,4 +82,16 @@ public class ArticleController {
     public Mono<ResponseEntity<Void>> acceptArticle(@PathVariable String articleId) {
         return articleService.acceptArticle(articleId).then(Mono.just(ResponseEntity.noContent().build()));
     }
+
+    @PostMapping(value = "/acceptDraft" , produces = MediaType.APPLICATION_JSON_VALUE)
+    public Mono<ResponseEntity<ArticleResponseModel>> createArticleDraft(@RequestBody ArticleRequestModel articleRequestModel) {
+        return articleService.createArticleDraft(Mono.just(articleRequestModel))
+                .map(articleResponseModel -> ResponseEntity
+                        .status(HttpStatus.CREATED)
+                        .body(articleResponseModel))
+                .onErrorResume(e -> Mono.just(
+                        ResponseEntity
+                                .status(HttpStatus.BAD_REQUEST)
+                                .body(null)));
+    }
 }

--- a/computer_alerts-be/src/test/java/com/calerts/computer_alertsbe/articlesubdomain/businesslayer/ArticleServiceUnitTest.java
+++ b/computer_alerts-be/src/test/java/com/calerts/computer_alertsbe/articlesubdomain/businesslayer/ArticleServiceUnitTest.java
@@ -331,6 +331,20 @@ class ArticleServiceUnitTest {
                 .expectError(BadRequestException.class)
                 .verify();
     }
+    @Test
+    void createArticleDraft_emptyTitle_shouldThrowBadRequestException() {
+        // Arrange
+        ArticleRequestModel invalidArticleRequest = ArticleRequestModel.builder()
+                .title("")
+                .body("Some body")
+                .wordCount(120)
+                .build();
+
+        // Act and Assert
+        StepVerifier.create(articleService.createArticleDraft(Mono.just(invalidArticleRequest)))
+                .expectError(BadRequestException.class)
+                .verify();
+    }
 
     @Test
     void createArticle_insufficientWordCount_shouldThrowBadRequestException() {
@@ -343,6 +357,20 @@ class ArticleServiceUnitTest {
 
         // Act and Assert
         StepVerifier.create(articleService.createArticle(Mono.just(invalidArticleRequest)))
+                .expectError(BadRequestException.class)
+                .verify();
+    }
+    @Test
+    void createArticleDraft_insufficientWordCount_shouldThrowBadRequestException() {
+        // Arrange
+        ArticleRequestModel invalidArticleRequest = ArticleRequestModel.builder()
+                .title("Test Title")
+                .body("Short body")
+                .wordCount(50)
+                .build();
+
+        // Act and Assert
+        StepVerifier.create(articleService.createArticleDraft(Mono.just(invalidArticleRequest)))
                 .expectError(BadRequestException.class)
                 .verify();
     }

--- a/computer_alerts-be/src/test/java/com/calerts/computer_alertsbe/articlesubdomain/businesslayer/ArticleServiceUnitTest.java
+++ b/computer_alerts-be/src/test/java/com/calerts/computer_alertsbe/articlesubdomain/businesslayer/ArticleServiceUnitTest.java
@@ -282,6 +282,42 @@ class ArticleServiceUnitTest {
     }
 
     @Test
+    void createArticleDraft_validArticle_shouldCreateAndReturnArticle() {
+        // Arrange
+        ArticleRequestModel validArticleRequest = ArticleRequestModel.builder()
+                .title("Test Article")
+                .body("This is a valid test article with sufficient word count to pass the validation.")
+                .wordCount(120)
+                .tags("NBA")
+                .build();
+
+        Article savedArticle = Article.builder()
+                .articleIdentifier(new ArticleIdentifier())
+                .title(validArticleRequest.getTitle())
+                .body(validArticleRequest.getBody())
+                .wordCount(validArticleRequest.getWordCount())
+                .articleStatus(ArticleStatus.DRAFT)
+                .tags(validArticleRequest.getTags())
+                .requestCount(0)
+                .timePosted(ZonedDateTime.now().toLocalDateTime())
+                .build();
+
+        // Mock the repository save method to return the saved article
+        when(articleRepository.save(any(Article.class)))
+                .thenReturn(Mono.just(savedArticle));
+
+        // Act and Assert
+        StepVerifier.create(articleService.createArticleDraft(Mono.just(validArticleRequest)))
+                .expectNextMatches(responseModel ->
+                        responseModel.getTitle().equals(validArticleRequest.getTitle()) &&
+                                responseModel.getWordCount() == validArticleRequest.getWordCount() &&
+                                responseModel.getArticleStatus() == ArticleStatus.DRAFT
+                )
+                .verifyComplete();
+    }
+
+
+    @Test
     void createArticle_emptyTitle_shouldThrowBadRequestException() {
         // Arrange
         ArticleRequestModel invalidArticleRequest = ArticleRequestModel.builder()

--- a/computer_alerts-be/src/test/java/com/calerts/computer_alertsbe/articlesubdomain/presentationlayer/ArticleControllerIntegrationTest.java
+++ b/computer_alerts-be/src/test/java/com/calerts/computer_alertsbe/articlesubdomain/presentationlayer/ArticleControllerIntegrationTest.java
@@ -239,6 +239,32 @@ class ArticleControllerIntegrationTest {
                     assertEquals(ArticleStatus.ARTICLE_REVIEW, response.getArticleStatus());
                 });
     }
+    @Test
+    @WithMockUser(username = "testuser", roles = {"ADMIN"})
+    void whenCreateDraftValidArticle_thenReturnCreatedArticle() {
+        // Arrange
+        ArticleRequestModel articleRequestModel = ArticleRequestModel.builder()
+                .title("Test Article")
+                .body("This is a detailed test article with sufficient word count to pass validation.")
+                .wordCount(120)
+                .tags("NBA")
+                .build();
+
+        // Act & Assert
+        webTestClient.post()
+                .uri(BASE_URL +"/acceptDraft")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(articleRequestModel)
+                .exchange()
+                .expectStatus().isCreated()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectBody(ArticleResponseModel.class)
+                .value(response -> {
+                    assertNotNull(response);
+                    assertEquals(articleRequestModel.getTitle(), response.getTitle());
+                    assertEquals(ArticleStatus.DRAFT, response.getArticleStatus());
+                });
+    }
 
     @Test
     @WithMockUser(username = "testuser", roles = {"ADMIN"})
@@ -253,6 +279,24 @@ class ArticleControllerIntegrationTest {
         // Act & Assert
         webTestClient.post()
                 .uri(BASE_URL)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(invalidArticleRequest)
+                .exchange()
+                .expectStatus().isBadRequest();
+    }
+    @Test
+    @WithMockUser(username = "testuser", roles = {"ADMIN"})
+    void whenCreateArticleDraftWithInvalidData_thenReturnBadRequest() {
+        // Arrange
+        ArticleRequestModel invalidArticleRequest = ArticleRequestModel.builder()
+                .title("")
+                .body("Short body")
+                .wordCount(50)
+                .build();
+
+        // Act & Assert
+        webTestClient.post()
+                .uri(BASE_URL + "/acceptDraft")
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(invalidArticleRequest)
                 .exchange()

--- a/computer_alerts-fe/src/App.tsx
+++ b/computer_alerts-fe/src/App.tsx
@@ -29,7 +29,8 @@ const Navbar = () => {
     location.pathname.startsWith("/authDashboard") ||
     location.pathname.startsWith("/authHome") ||
     location.pathname.startsWith("/authCreateArticle") ||
-    location.pathname.startsWith("/authYourArticles")
+    location.pathname.startsWith("/authYourArticles") ||
+    location.pathname.startsWith("/authYourDrafts")
   ) {
     return <AuthorNavBar />;
   } else if (
@@ -84,6 +85,10 @@ function App(): JSX.Element {
 
           <Route
             path={AppRoutePaths.ArticlesByTag}
+            element={<ArticlesPage />}
+          />
+          <Route
+            path={AppRoutePaths.AutherDrafts}
             element={<ArticlesPage />}
           />
           <Route path={AppRoutePaths.Authors} element={<AuthorPage />} />

--- a/computer_alerts-fe/src/App.tsx
+++ b/computer_alerts-fe/src/App.tsx
@@ -21,6 +21,7 @@ import AdminHomePage from "pages/AdminPages/Home-Page/AdminHomePage";
 import AdminReviewArticles from "pages/AdminPages/Review-Articles/ReviewArticles";
 import AdminNavBar from "./layouts/AdminDashboard/AdminNavBar";
 import AdminArticleDetails from "./pages/AdminPages/AdminArticleDetails/AdminArticleDetails";
+import ArtifleDrafts from "pages/AutherPages/ArticleDrafts/ArticleDrafts";
 
 const Navbar = () => {
   const location = useLocation();
@@ -89,7 +90,7 @@ function App(): JSX.Element {
           />
           <Route
             path={AppRoutePaths.AutherDrafts}
-            element={<ArticlesPage />}
+            element={<ArtifleDrafts />}
           />
           <Route path={AppRoutePaths.Authors} element={<AuthorPage />} />
           <Route

--- a/computer_alerts-fe/src/features/articles/components/ArticleDetails/ArticleDetails.tsx
+++ b/computer_alerts-fe/src/features/articles/components/ArticleDetails/ArticleDetails.tsx
@@ -152,8 +152,7 @@ const ArticleDetails: React.FC = () => {
       <div className="comments-section">
         <h2 className="comments-title">Comments</h2>
         <CommentList articleId={{ articleId: article.articleId }} />
-        <div className="comments-list">
-        </div>
+        <div className="comments-list"></div>
         <textarea
           value={newComment}
           onChange={(e) => setNewComment(e.target.value)}

--- a/computer_alerts-fe/src/features/comments/api/addComment.ts
+++ b/computer_alerts-fe/src/features/comments/api/addComment.ts
@@ -1,15 +1,17 @@
 import { CommentModel } from "../model/CommentModel";
 import axiosInstance from "../model/commentsAxiosInstance";
 
-export async function addComment(comment:Partial<CommentModel>): Promise<void> {
-    try {
-        const response = await axiosInstance.post<void>('', comment);
-        return response.data;
-      } catch (err) {
-        console.error("Error posting comments", err);
-        throw err;
-      }
-} 
+export async function addComment(
+  comment: Partial<CommentModel>,
+): Promise<void> {
+  try {
+    const response = await axiosInstance.post<void>("", comment);
+    return response.data;
+  } catch (err) {
+    console.error("Error posting comments", err);
+    throw err;
+  }
+}
 
 // export const addComment = async (): Promise<void> => {
 //   try {

--- a/computer_alerts-fe/src/features/comments/api/getAllComments.ts
+++ b/computer_alerts-fe/src/features/comments/api/getAllComments.ts
@@ -12,6 +12,8 @@
 // };
 
 export const getAllComments = () => {
-  const eventSource = new EventSource('http://localhost:8080/api/v1/interactions/comments');
+  const eventSource = new EventSource(
+    "http://localhost:8080/api/v1/interactions/comments",
+  );
   return eventSource;
 };

--- a/computer_alerts-fe/src/features/comments/components/CommentList.css
+++ b/computer_alerts-fe/src/features/comments/components/CommentList.css
@@ -1,36 +1,36 @@
 .comments-container {
-    margin: 20px 0;
-    width: 100%;
-  }
-  
-  .comments-box {
-    border: 1px solid #ddd;
-    border-radius: 8px;
-    padding: 15px;
-    background-color: #f8f9fa;
-    max-height: 500px;
-    overflow-y: auto;
-  }
-  
-  .comment-item {
-    background-color: white;
-    border: 1px solid #eee;
-    border-radius: 4px;
-    padding: 10px;
-    margin-bottom: 10px;
-  }
-  
-  .comment-item:last-child {
-    margin-bottom: 0;
-  }
-  
-  .no-comments {
-    text-align: center;
-    color: #666;
-    padding: 20px;
-  }
+  margin: 20px 0;
+  width: 100%;
+}
 
-  .reader-id {
-    color: #586AAF;
-    font-weight: 500;
-  }
+.comments-box {
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  padding: 15px;
+  background-color: #f8f9fa;
+  max-height: 500px;
+  overflow-y: auto;
+}
+
+.comment-item {
+  background-color: white;
+  border: 1px solid #eee;
+  border-radius: 4px;
+  padding: 10px;
+  margin-bottom: 10px;
+}
+
+.comment-item:last-child {
+  margin-bottom: 0;
+}
+
+.no-comments {
+  text-align: center;
+  color: #666;
+  padding: 20px;
+}
+
+.reader-id {
+  color: #586aaf;
+  font-weight: 500;
+}

--- a/computer_alerts-fe/src/features/comments/components/CommentList.tsx
+++ b/computer_alerts-fe/src/features/comments/components/CommentList.tsx
@@ -6,7 +6,9 @@ interface CommentListProps {
   articleId: { articleId: string };
 }
 
-const CommentList: React.FC<CommentListProps> = ({ articleId: { articleId } }) => {
+const CommentList: React.FC<CommentListProps> = ({
+  articleId: { articleId },
+}) => {
   const [comments, setComments] = useState<CommentModel[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
@@ -15,7 +17,9 @@ const CommentList: React.FC<CommentListProps> = ({ articleId: { articleId } }) =
     const seenCommentIds = new Set<string>();
 
     const connectToSSE = () => {
-      eventSource = new EventSource('http://localhost:8080/api/v1/interactions/comments');
+      eventSource = new EventSource(
+        "http://localhost:8080/api/v1/interactions/comments",
+      );
 
       eventSource.onopen = () => {
         setIsLoading(false);
@@ -24,7 +28,10 @@ const CommentList: React.FC<CommentListProps> = ({ articleId: { articleId } }) =
       eventSource.onmessage = (event) => {
         try {
           const newComment: CommentModel = JSON.parse(event.data);
-          if (newComment.articleId === articleId && !seenCommentIds.has(newComment.commentId)) {
+          if (
+            newComment.articleId === articleId &&
+            !seenCommentIds.has(newComment.commentId)
+          ) {
             seenCommentIds.add(newComment.commentId);
             setComments((prevComments) => [...prevComments, newComment]);
           }
@@ -46,9 +53,11 @@ const CommentList: React.FC<CommentListProps> = ({ articleId: { articleId } }) =
   // const filteredComments = comments.filter(comment => comment.articleId === articleId);
 
   const filteredComments = comments
-  .filter(comment => comment.articleId === articleId)
-  .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
-
+    .filter((comment) => comment.articleId === articleId)
+    .sort(
+      (a, b) =>
+        new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
+    );
 
   if (isLoading) {
     return <div>Loading comments...</div>;
@@ -60,13 +69,18 @@ const CommentList: React.FC<CommentListProps> = ({ articleId: { articleId } }) =
         {filteredComments.length > 0 ? (
           filteredComments.map((comment) => (
             <div key={comment.commentId} className="comment-item">
-              <p><strong>Reader ID:</strong> <span className="reader-id">{comment.readerId}</span></p>
+              <p>
+                <strong>Reader ID:</strong>{" "}
+                <span className="reader-id">{comment.readerId}</span>
+              </p>
               <p>{comment.content}</p>
               {/* <p><strong>Timestamp:</strong> {new Date(comment.timestamp).toLocaleString()}</p> */}
             </div>
           ))
         ) : (
-          <p className="no-comments">No comments yet. Be the first to comment!</p>
+          <p className="no-comments">
+            No comments yet. Be the first to comment!
+          </p>
         )}
       </div>
     </div>

--- a/computer_alerts-fe/src/features/comments/model/CommentModel.ts
+++ b/computer_alerts-fe/src/features/comments/model/CommentModel.ts
@@ -1,9 +1,8 @@
-  export interface CommentModel {
-    commentId: string;
-    content: string;
-    wordCount: number;
-    timestamp: Date;
-    articleId: string;
-    readerId: string;
-  }
-  
+export interface CommentModel {
+  commentId: string;
+  content: string;
+  wordCount: number;
+  timestamp: Date;
+  articleId: string;
+  readerId: string;
+}

--- a/computer_alerts-fe/src/features/comments/model/commentsAxiosInstance.ts
+++ b/computer_alerts-fe/src/features/comments/model/commentsAxiosInstance.ts
@@ -1,11 +1,11 @@
-import axios from 'axios';
+import axios from "axios";
 
 const axiosInstance = axios.create({
-    baseURL: 'http://localhost:8080/api/v1/interactions/comments',
-    headers: {
-        'Content-Type': 'application/json',
-        'Accept': 'application/json'
-    }
+  baseURL: "http://localhost:8080/api/v1/interactions/comments",
+  headers: {
+    "Content-Type": "application/json",
+    Accept: "application/json",
+  },
 });
 
 export default axiosInstance;

--- a/computer_alerts-fe/src/layouts/AutherDashboard/AutherNavBar.tsx
+++ b/computer_alerts-fe/src/layouts/AutherDashboard/AutherNavBar.tsx
@@ -28,6 +28,15 @@ export default function AuthorNavBar(): JSX.Element {
               Your Articles
             </Nav.Link>
           </Nav>
+          <Nav className="ms-auto">
+            <Nav.Link
+              as={Link}
+              to={AppRoutePaths.AutherDrafts}
+              className="nav-link"
+            >
+              Draft Articles
+            </Nav.Link>
+          </Nav>
         </Navbar.Collapse>
       </Container>
     </Navbar>

--- a/computer_alerts-fe/src/pages/AdminPages/AdminArticleDetails/AdminArticleDetails.tsx
+++ b/computer_alerts-fe/src/pages/AdminPages/AdminArticleDetails/AdminArticleDetails.tsx
@@ -50,6 +50,9 @@ const AdminArticleDetails: React.FC = () => {
   if (!article) return <p>No article found.</p>;
 
   return (
+
+
+    
     <div className="container con-color">
       <br />
       <br />
@@ -58,13 +61,16 @@ const AdminArticleDetails: React.FC = () => {
           <div className="sameLine space-between">
             <h1>Review Article</h1>
 
-            <div className="row sameLine "></div>
+            <div className="row sameLine ">
+            </div>
           </div>
         </div>
-
+       
         <br />
         <hr />
         <br />
+       
+        
 
         <div className="row">
           <div className="col-12">
@@ -77,9 +83,11 @@ const AdminArticleDetails: React.FC = () => {
           </div>
         </div>
 
+       
         <br />
         <hr />
         <br />
+      
 
         <div className="row">
           <div className="col-12 sameLine space-between">
@@ -90,9 +98,11 @@ const AdminArticleDetails: React.FC = () => {
           </div>
         </div>
 
+       
         <br />
         <hr />
         <br />
+        
 
         {/* <div className="row">
           <div className="col-12">
@@ -114,33 +124,34 @@ const AdminArticleDetails: React.FC = () => {
           </div>
         </div>
 
+
+      
         <br />
         <hr />
         <br />
 
+
         <div className="row">
-          <div className="col-12">
-            <button className="red-button">Change is needed</button>
-          </div>
-        </div>
+  <div className="col-12">
+    <button className="red-button">Change is needed</button>
+  </div>
+</div>
 
         <div className="row sameline lastRow">
-          <div className="col-6">
-            <button
-              onClick={handleCancelButton}
-              className="btn btn-secondary center"
-            >
+            <div className="col-6 margin-butta">
+            <button onClick={handleCancelButton} className="btn btn-secondary center">
               Cancel
             </button>
-          </div>
-          <div className="col-6">
+
+            </div>
+            <div className="col-6">
             <button
               onClick={handleAcceptArticle}
               className="accept-article-button btn btn-success bold"
             >
               Accept Article
             </button>
-          </div>
+            </div>           
         </div>
 
         {successMessage && (

--- a/computer_alerts-fe/src/pages/AdminPages/AdminArticleDetails/AdminArticleDetails.tsx
+++ b/computer_alerts-fe/src/pages/AdminPages/AdminArticleDetails/AdminArticleDetails.tsx
@@ -50,9 +50,6 @@ const AdminArticleDetails: React.FC = () => {
   if (!article) return <p>No article found.</p>;
 
   return (
-
-
-    
     <div className="container con-color">
       <br />
       <br />
@@ -61,16 +58,13 @@ const AdminArticleDetails: React.FC = () => {
           <div className="sameLine space-between">
             <h1>Review Article</h1>
 
-            <div className="row sameLine ">
-            </div>
+            <div className="row sameLine "></div>
           </div>
         </div>
-       
+
         <br />
         <hr />
         <br />
-       
-        
 
         <div className="row">
           <div className="col-12">
@@ -83,11 +77,9 @@ const AdminArticleDetails: React.FC = () => {
           </div>
         </div>
 
-       
         <br />
         <hr />
         <br />
-      
 
         <div className="row">
           <div className="col-12 sameLine space-between">
@@ -98,11 +90,9 @@ const AdminArticleDetails: React.FC = () => {
           </div>
         </div>
 
-       
         <br />
         <hr />
         <br />
-        
 
         {/* <div className="row">
           <div className="col-12">
@@ -124,34 +114,33 @@ const AdminArticleDetails: React.FC = () => {
           </div>
         </div>
 
-
-      
         <br />
         <hr />
         <br />
 
-
         <div className="row">
-  <div className="col-12">
-    <button className="red-button">Change is needed</button>
-  </div>
-</div>
+          <div className="col-12">
+            <button className="red-button">Change is needed</button>
+          </div>
+        </div>
 
         <div className="row sameline lastRow">
-            <div className="col-6 margin-butta">
-            <button onClick={handleCancelButton} className="btn btn-secondary center">
+          <div className="col-6 margin-butta">
+            <button
+              onClick={handleCancelButton}
+              className="btn btn-secondary center"
+            >
               Cancel
             </button>
-
-            </div>
-            <div className="col-6">
+          </div>
+          <div className="col-6">
             <button
               onClick={handleAcceptArticle}
               className="accept-article-button btn btn-success bold"
             >
               Accept Article
             </button>
-            </div>           
+          </div>
         </div>
 
         {successMessage && (

--- a/computer_alerts-fe/src/pages/AdminPages/AdminArticleDetails/AdminArticleDetails.tsx
+++ b/computer_alerts-fe/src/pages/AdminPages/AdminArticleDetails/AdminArticleDetails.tsx
@@ -126,10 +126,7 @@ const AdminArticleDetails: React.FC = () => {
 
         <div className="row sameline lastRow">
           <div className="col-6 margin-butta">
-            <button
-              onClick={handleCancelButton}
-              className="btn btn-secondary center"
-            >
+            <button onClick={handleCancelButton} className="btn btn-secondary">
               Cancel
             </button>
           </div>

--- a/computer_alerts-fe/src/pages/ArticlePages/CreateArticle/ArticleForm.css
+++ b/computer_alerts-fe/src/pages/ArticlePages/CreateArticle/ArticleForm.css
@@ -53,7 +53,7 @@
   margin-top: 1rem;
 }
 
-.article-form-draft button[type="submit"] {
+.article-form-draft{
   background-color: rosybrown; /* Green color */
   color: white;
   padding: 1rem 2rem;

--- a/computer_alerts-fe/src/pages/ArticlePages/CreateArticle/ArticleForm.css
+++ b/computer_alerts-fe/src/pages/ArticlePages/CreateArticle/ArticleForm.css
@@ -53,7 +53,7 @@
   margin-top: 1rem;
 }
 
-.article-form-draft{
+.article-form-draft {
   background-color: rosybrown; /* Green color */
   color: white;
   padding: 1rem 2rem;

--- a/computer_alerts-fe/src/pages/ArticlePages/CreateArticle/ArticleForm.css
+++ b/computer_alerts-fe/src/pages/ArticlePages/CreateArticle/ArticleForm.css
@@ -53,6 +53,17 @@
   margin-top: 1rem;
 }
 
+.article-form-draft button[type="submit"] {
+  background-color: rosybrown; /* Green color */
+  color: white;
+  padding: 1rem 2rem;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 16px;
+  margin-top: 1rem;
+}
+
 .article-form button[type="submit"]:hover {
   background-color: #45a049; /* Darker green on hover */
 }

--- a/computer_alerts-fe/src/pages/ArticlePages/CreateArticle/ArticleForm.tsx
+++ b/computer_alerts-fe/src/pages/ArticlePages/CreateArticle/ArticleForm.tsx
@@ -64,6 +64,27 @@ const ArticleForm = () => {
     }
   };
 
+  const handleDraftSubmit = async () => {
+    try {
+      const response = await axios.post(
+        "http://localhost:8080/api/v1/articles/acceptDraft",
+        formData,
+      );
+      console.log("Article saved:", response.data);
+      setSuccessMessageText(
+        "You have successfully created a Draft of your article.",
+      );
+      setShowSuccessMessage(true);
+
+      // Hide success message after 3 seconds
+      setTimeout(() => {
+        setShowSuccessMessage(false);
+      }, 3000);
+    } catch (error) {
+      console.error("Error creating article:", error);
+    }
+  };
+
   const handlePopupAccept = () => {
     setShowPopup(false);
     handleSubmit();
@@ -117,9 +138,23 @@ const ArticleForm = () => {
           <option value={TagsTagEnum.Tag4}>NFL</option>
           <option value={TagsTagEnum.Tag5}>MLB</option>
         </select>
-        <button type="submit" className="article-form__button">
-          Create Article
-        </button>
+
+        <div className="row">
+          <div className="col-6">
+            <button
+              type="submit"
+              onClick={handleDraftSubmit}
+              className="article-form-draft__button"
+            >
+              Draft Article
+            </button>
+          </div>
+          <div className="col-6">
+            <button type="submit" className="article-form__button">
+              Create Article
+            </button>
+          </div>
+        </div>
       </form>
 
       {showPopup && (

--- a/computer_alerts-fe/src/pages/ArticlePages/CreateArticle/ArticleForm.tsx
+++ b/computer_alerts-fe/src/pages/ArticlePages/CreateArticle/ArticleForm.tsx
@@ -144,7 +144,7 @@ const ArticleForm = () => {
             <button
               type="submit"
               onClick={handleDraftSubmit}
-              className="article-form-draft__button"
+              className="article-form-draft"
             >
               Draft Article
             </button>

--- a/computer_alerts-fe/src/pages/ArticlePages/CreateArticle/ArticleForm.tsx
+++ b/computer_alerts-fe/src/pages/ArticlePages/CreateArticle/ArticleForm.tsx
@@ -74,12 +74,12 @@ const ArticleForm = () => {
       setSuccessMessageText(
         "You have successfully created a Draft of your article.",
       );
-      setShowSuccessMessage(true);
+      // setShowSuccessMessage(true);
 
-      // Hide success message after 3 seconds
-      setTimeout(() => {
-        setShowSuccessMessage(false);
-      }, 3000);
+      // // Hide success message after 3 seconds
+      // setTimeout(() => {
+      //   setShowSuccessMessage(false);
+      // }, 3000);
     } catch (error) {
       console.error("Error creating article:", error);
     }
@@ -141,11 +141,7 @@ const ArticleForm = () => {
 
         <div className="row">
           <div className="col-6">
-            <button
-              type="submit"
-              onClick={handleDraftSubmit}
-              className="article-form-draft"
-            >
+            <button onClick={handleDraftSubmit} className="article-form-draft">
               Draft Article
             </button>
           </div>

--- a/computer_alerts-fe/src/pages/AutherPages/ArticleDrafts/ArticleDrafts.tsx
+++ b/computer_alerts-fe/src/pages/AutherPages/ArticleDrafts/ArticleDrafts.tsx
@@ -36,7 +36,7 @@ const ArtifleDrafts: React.FC = () => {
   if (error) return <p className="text-center text-danger">{error}</p>;
   return (
     <div className="container review-articles">
-      <h1>Here are your articles to review</h1>
+      <h1>Here are your drafted articles.</h1>
       {articles.length > 0 ? (
         <div className="review-articles__list">
           {articles.map((article) => (

--- a/computer_alerts-fe/src/pages/AutherPages/ArticleDrafts/ArticleDrafts.tsx
+++ b/computer_alerts-fe/src/pages/AutherPages/ArticleDrafts/ArticleDrafts.tsx
@@ -1,0 +1,62 @@
+import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { fetchAllsArticles } from "../../../features/articles/api/getAllArticles";
+import { ArticleRequestModel } from "../../../features/articles/models/ArticleRequestModel";
+import ArticleMainComponent from "../../ArticlePages/ArticleMainComponent";
+import "./ArticleDrafts.css"
+
+const ArtifleDrafts: React.FC = () =>{
+    const navigate = useNavigate();
+  const [articles, setArticles] = useState<ArticleRequestModel[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchArticles = async () => {
+      try {
+        const allArticles = await fetchAllsArticles();
+        const articlesToReview = allArticles.filter(
+          (article: ArticleRequestModel) =>
+            article.articleStatus === "DRAFT",
+        );
+        setArticles(articlesToReview);
+      } catch (err) {
+        setError("Failed to fetch articles. Please try again later.");
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchArticles();
+  }, []);
+
+  const handleArticleClick = (id: string) => {
+    navigate(`/article/${id}`);
+  };
+
+  if (loading) return <p className="text-center">Loading articles...</p>;
+  if (error) return <p className="text-center text-danger">{error}</p>;
+  return (
+    <div className="container review-articles">
+      <h1>Here are your articles to review</h1>
+      {articles.length > 0 ? (
+        <div className="review-articles__list">
+          {articles.map((article) => (
+            <ArticleMainComponent
+              key={article.articleId}
+              imageURL={article.photoUrl}
+              title={article.title}
+              description={`Word Count: ${article.wordCount}`}
+              tags={article.tags}
+              onClick={() => handleArticleClick(article.articleId)}
+            />
+          ))}
+        </div>
+      ) : (
+        <p className="text-center">No articles to review at the moment.</p>
+      )}
+    </div>
+  );
+};
+
+
+export default ArtifleDrafts;

--- a/computer_alerts-fe/src/pages/AutherPages/ArticleDrafts/ArticleDrafts.tsx
+++ b/computer_alerts-fe/src/pages/AutherPages/ArticleDrafts/ArticleDrafts.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+// import { useNavigate } from "react-router-dom";
 import { fetchAllsArticles } from "../../../features/articles/api/getAllArticles";
 import { ArticleRequestModel } from "../../../features/articles/models/ArticleRequestModel";
 import ArticleMainComponent from "../../ArticlePages/ArticleMainComponent";
 import "./ArticleDrafts.css";
 
 const ArtifleDrafts: React.FC = () => {
-  const navigate = useNavigate();
+//   const navigate = useNavigate();
   const [articles, setArticles] = useState<ArticleRequestModel[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);

--- a/computer_alerts-fe/src/pages/AutherPages/ArticleDrafts/ArticleDrafts.tsx
+++ b/computer_alerts-fe/src/pages/AutherPages/ArticleDrafts/ArticleDrafts.tsx
@@ -29,7 +29,7 @@ const ArtifleDrafts: React.FC = () => {
   }, []);
 
   const handleArticleClick = (id: string) => {
-    navigate(`/article/${id}`);
+    return null;
   };
 
   if (loading) return <p className="text-center">Loading articles...</p>;

--- a/computer_alerts-fe/src/pages/AutherPages/ArticleDrafts/ArticleDrafts.tsx
+++ b/computer_alerts-fe/src/pages/AutherPages/ArticleDrafts/ArticleDrafts.tsx
@@ -3,10 +3,10 @@ import { useNavigate } from "react-router-dom";
 import { fetchAllsArticles } from "../../../features/articles/api/getAllArticles";
 import { ArticleRequestModel } from "../../../features/articles/models/ArticleRequestModel";
 import ArticleMainComponent from "../../ArticlePages/ArticleMainComponent";
-import "./ArticleDrafts.css"
+import "./ArticleDrafts.css";
 
-const ArtifleDrafts: React.FC = () =>{
-    const navigate = useNavigate();
+const ArtifleDrafts: React.FC = () => {
+  const navigate = useNavigate();
   const [articles, setArticles] = useState<ArticleRequestModel[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
@@ -16,8 +16,7 @@ const ArtifleDrafts: React.FC = () =>{
       try {
         const allArticles = await fetchAllsArticles();
         const articlesToReview = allArticles.filter(
-          (article: ArticleRequestModel) =>
-            article.articleStatus === "DRAFT",
+          (article: ArticleRequestModel) => article.articleStatus === "DRAFT",
         );
         setArticles(articlesToReview);
       } catch (err) {
@@ -57,6 +56,5 @@ const ArtifleDrafts: React.FC = () =>{
     </div>
   );
 };
-
 
 export default ArtifleDrafts;

--- a/computer_alerts-fe/src/shared/models/path.routes.ts
+++ b/computer_alerts-fe/src/shared/models/path.routes.ts
@@ -16,6 +16,7 @@ export enum AppRoutePaths {
   AuthorHomePage = "/authHome",
   AutherYourArticle = "/authYourArticles",
   AutherCreateArticle = "/authCreateArticle",
+  AutherDrafts = "/authYourDrafts",
 
   //
   //

--- a/computer_alerts-fe/tests/articlepage/comment.spec.ts
+++ b/computer_alerts-fe/tests/articlepage/comment.spec.ts
@@ -1,34 +1,44 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from "@playwright/test";
 
-test('Add Comment in ArticlePage', async ({ page }) => {
-  await page.goto('http://localhost:3000/articles/ca1d0478-6a9c-421b-b815-84965e3c7b4a');
-  await page.getByPlaceholder('Write a comment...').click();
-  await page.getByPlaceholder('Write a comment...').fill('I was first ;)');
-  await page.getByRole('button', { name: 'Add Comment' }).click();
-  await expect(page.locator('#root')).toContainText('I was first ;)');
+test("Add Comment in ArticlePage", async ({ page }) => {
+  await page.goto(
+    "http://localhost:3000/articles/ca1d0478-6a9c-421b-b815-84965e3c7b4a",
+  );
+  await page.getByPlaceholder("Write a comment...").click();
+  await page.getByPlaceholder("Write a comment...").fill("I was first ;)");
+  await page.getByRole("button", { name: "Add Comment" }).click();
+  await expect(page.locator("#root")).toContainText("I was first ;)");
 
   await page.close();
 });
 
-test('Big Comment in ArticlePage', async ({ page }) => {
-  await page.goto('http://localhost:3000/articles/ca1d0478-6a9c-421b-b815-84965e3c7b4a');
-  await page.getByPlaceholder('Write a comment...').click();
-  await page.getByPlaceholder('Write a comment...').fill('Apple mountain laptop freedom universe ' +
-    'lighthouse keyboard ocean guitar willow cloud chocolate forest puzzle eagle rainbow sunset journey ' +
-    'memory adventure snowflake volcano window dream notebook river camera compass heart horizon butterfly ' +
-    'rocket whisper symphony puzzle treasure star galaxy secret flame oasis harmony meadow turtle dolphin ' +
-    'book breeze lantern melody anchor mountain.');
+test("Big Comment in ArticlePage", async ({ page }) => {
+  await page.goto(
+    "http://localhost:3000/articles/ca1d0478-6a9c-421b-b815-84965e3c7b4a",
+  );
+  await page.getByPlaceholder("Write a comment...").click();
+  await page
+    .getByPlaceholder("Write a comment...")
+    .fill(
+      "Apple mountain laptop freedom universe " +
+        "lighthouse keyboard ocean guitar willow cloud chocolate forest puzzle eagle rainbow sunset journey " +
+        "memory adventure snowflake volcano window dream notebook river camera compass heart horizon butterfly " +
+        "rocket whisper symphony puzzle treasure star galaxy secret flame oasis harmony meadow turtle dolphin " +
+        "book breeze lantern melody anchor mountain.",
+    );
 
-    // Create dialog handler before click
-  const dialogPromise = page.waitForEvent('dialog');
-  page.once('dialog', dialog => {
+  // Create dialog handler before click
+  const dialogPromise = page.waitForEvent("dialog");
+  page.once("dialog", (dialog) => {
     dialog.dismiss().catch(() => {});
   });
-  await page.getByRole('button', { name: 'Add Comment' }).click();
-  
+  await page.getByRole("button", { name: "Add Comment" }).click();
+
   // Handle dialog and assert message
   const dialog = await dialogPromise;
-  expect(dialog.message()).toBe('Comment is too long. Please keep it under 50 words.');
-    
+  expect(dialog.message()).toBe(
+    "Comment is too long. Please keep it under 50 words.",
+  );
+
   await page.close();
 });


### PR DESCRIPTION
JIRA: https://champlainsaintlambert.atlassian.net/browse/LA-17

## Context:
An author can now view his saved articles as a draft. This means when create an article he can now press the button save as draft. This will put the article status enum as Draft. This article will not be open to the public since we only query articles that status is published. 

## Changes:
Added a http post request in order for the status to be created but wit the article status as set to DRAFT when created. 

## Before and After UI (Required for UI-impacting PRs)
If this is a change to the UI, include before and after screenshots to show the differences.
If this is a new UI feature, include screenshots to show reviewers what it looks like. 

**BEFORE**
`In the navbar ther was not a draft articles section. `
`As of now we can only display the drafted articles and not do anything with  them when clicking it`


**AFTER**
![image](https://github.com/user-attachments/assets/dbfb2a8d-e857-4b87-872c-403eaa7a8445)
![image](https://github.com/user-attachments/assets/d41ec89f-1c32-4edd-8caa-bd32c9bf0fe5)
![image](https://github.com/user-attachments/assets/ff862021-5388-43e8-b9ce-ff30eb3f2506)





